### PR TITLE
Link to latest version of Kupfer (321)

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,11 @@ applications.</p>
 
 <span class="header">
 
-<a href="https://github.com/kupferlauncher/kupfer/releases/tag/v319">v319</a>
+<a href="https://github.com/kupferlauncher/kupfer/releases/tag/v321">v321</a>
 
 </span>
-<p>Source tarball: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/releases/download/v319/kupfer-v319.tar.xz">kupfer-v319.tar.xz</a></p>
-<p>Release notes: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/blob/v319/Documentation/VersionHistory.rst">Documentation/VersionHistory.rst</a></p>
+<p>Source tarball: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/releases/download/v321/kupfer-v321.tar.xz">kupfer-v321.tar.xz</a></p>
+<p>Release notes: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/blob/v321/Documentation/VersionHistory.rst">Documentation/VersionHistory.rst</a></p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ applications.</p>
 <a href="https://github.com/kupferlauncher/kupfer/releases/tag/v321">v321</a>
 
 </span>
-<p>Source tarball: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/releases/download/v321/kupfer-v321.tar.xz">kupfer-v321.tar.xz</a></p>
+<p>Source tarball: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/releases/download/v321/kupfer-v321.tar.bz2">kupfer-v321.tar.bz2</a></p>
 <p>Release notes: <a class="reference external" href="https://github.com/kupferlauncher/kupfer/blob/v321/Documentation/VersionHistory.rst">Documentation/VersionHistory.rst</a></p>
 
 


### PR DESCRIPTION
Updated links to point to version 321 instead of 319, also changed the filenames as 319 was using .tar.xz whereas 321 uses .tar.bz2