### PR TITLE
Remove reference to Ubuntu PPA

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,6 @@ You can set accelerator keys to often used actions,
 <dt>Ubuntu and Debian</dt>
 <dd>Kupfer is available in the repository under the package name <a class="reference external" href="apt:kupfer">kupfer</a>,
 you can install it with your package manager.</dd>
-<dt>Ubuntu PPA</dt>
-<dd><a href="https://launchpad.net/~webupd8team/+archive/ubuntu/kupfer">Kupfer v30x by WebUpd8 team</a><dd>
 <dt>Arch Linux</dt>
 <dd>Kupfer is available in the official <a class="reference external" href="https://www.archlinux.org/packages/community/any/kupfer/">community repository.</a></dd>
 </dl>


### PR DESCRIPTION
The PPA has not been updated for over 3 years and the version included
in the main repository is more up to date in the current and previous
LTS.